### PR TITLE
shapely 1.8.4

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,13 @@
-set LIB=%LIBRARY_LIB%;%LIB%
-set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
-set INCLUDE=%LIBRARY_INC%;%INCLUDE%;%RECIPE_DIR%
 
-set GEOS_LIBRARY_PATH=%LIBRARY_BIN%\geos_c.dll
+:: set GEOS_LIBRARY_PATH=%LIBRARY_BIN%
 
 del /f shapely\speedups\_speedups.c
 del /f shapely\vectorized\_vectorized.c
 
-cython shapely\speedups\_speedups.pyx
-cython shapely\vectorized\_vectorized.pyx
-
-"%PYTHON%" -m pip install --no-deps --ignore-installed --verbose . ^
-                          --global-option=build_ext ^
-                          --global-option="-I%LIBRARY_INC%" ^
-                          --global-option="-L%LIBRARY_LIB%" ^
-                          --global-option="-lgeos_c"
+"%PYTHON%" -m pip install . -vv ^
+    --no-deps --ignore-installed --no-use-pep517 ^
+    --global-option=build_ext ^
+    --global-option="-I%LIBRARY_INC%" ^
+    --global-option="-L%LIBRARY_LIB%" ^
+    --global-option="-lgeos_c"
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,31 @@
-{% set version = "1.7.1" %}
+{% set name = "Shapely" %}
+{% set version = "1.8.4" %}
 
 package:
-  name: shapely
+  name: {{ name|lower }}
   version: {{ version.split('.post')[0] }}
 
 source:
-  url: https://pypi.io/packages/source/S/Shapely/Shapely-{{ version }}.tar.gz
-  sha256: 1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a195e51caafa218291f2cbaa3fef69fd3353c93ec4b65b2a4722c4cf40c3198c
 
 build:
   number: 0
   skip: True  # [win and vc<14]
+  skip: True  # [py<36]
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
     - python
-    - pip
-    - cython
-    - numpy
+    - cython >=0.29.24,<3
     - geos
+    - numpy   1.19  # [py<310]
+    - numpy   1.21  # [py>=310]
+    - pip
+    - setuptools <64
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -29,26 +34,28 @@ test:
   source_files:
     - tests
   requires:
+    - pip
     - pytest
   imports:
     - shapely
-    - shapely.speedups
-    - shapely.speedups._speedups
-    - shapely.vectorized
-    - shapely.vectorized._vectorized
-    - shapely.geometry
     - shapely.algorithms
     - shapely.examples
-    - shapely.geos
+    - shapely.geometry
+    - shapely.speedups
+    - shapely.vectorized
   commands:
-    # skip one failure caused by geos 3.8
-    # https://github.com/Toblerity/Shapely/issues/777
-    - pytest -k "not OperationsTestCase" tests --with-speedups
+    - pip check
+
 about:
   home: https://github.com/Toblerity/Shapely
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
+  license_url: https://github.com/shapely/shapely/blob/main/LICENSE.txt
   summary: "Python package for manipulation and analysis of geometric objects in the Cartesian plane"
+
+  dev_url: https://github.com/Toblerity/Shapely
+  doc_url: https://shapely.readthedocs.io/en/stable/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,9 @@ source:
 
 build:
   number: 0
+  # geos currently isn't available on s390x
+  skip: True  # [py<36 or s390x]
   skip: True  # [win and vc<14]
-  skip: True  # [py<36]
 
 requirements:
   build:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,13 +1,34 @@
-from shapely import speedups;
+import platform
+import py
+import os
+import sys
 
-assert speedups.available;
+implementation = platform.python_implementation()
+print('implementation: {}'.format(implementation))
+target_platform = os.environ["target_platform"]
+print(f'target platform: {target_platform}')
+py_version = sys.version_info[:2]
+print(f'python version: {py_version}')
 
-speedups.enable()
+pytest_args = ['tests']
+
+if implementation != 'PyPy':
+    from shapely import speedups
+    import shapely.speedups._speedups
+    import shapely.vectorized
+    import shapely.vectorized._vectorized
+
+    assert speedups.available;
+
+    speedups.enable()
+    pytest_args.append('--with-speedups')
+
+py.test.cmdline.main(pytest_args)
 
 from shapely.geometry import LineString
 
 ls = LineString([(0, 0), (10, 0)])
-# On OSX causes an abort trap, due to https://github.com/Toblerity/Shapely/issues/177
+# On OSX causes an abort trap, due to https://github.com/shapely/shapely/issues/177
 r = ls.wkt
 area = ls.buffer(10).area
 


### PR DESCRIPTION
`easyocr 1.6.2` requires `shapely` but the existing version **1.7.1** has missing artifacts for `python 3.10` https://github.com/AnacondaRecipes/easyocr-feedstock/pull/1

Changelog: https://github.com/shapely/shapely/blob/1.8.4/CHANGES.txt
License: https://github.com/shapely/shapely/blob/main/LICENSE.txt
Requirements: 
- https://github.com/shapely/shapely/blob/1.8.4/pyproject.toml
- https://github.com/shapely/shapely/blob/1.8.4/setup.py

Actions:
1. Update `bld.bat` from conda-forge
2. Skip `py<36`, and `s390x` (`geos` isn't available)
3. Add pinnings for `host` dependencies: 
```
    - cython >=0.29.24,<3
    - numpy   1.19  # [py<310]
    - numpy   1.21  # [py>=310]
    - setuptools <64
```
4. Add `pip check`
5. Update `test/imports`
6. Add `license_family` & `license_url`
7. Add dev & doc urls
8. Update `run_test.py` from conda-forge